### PR TITLE
Add interactive prompts for Signal export

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ python export_signal_pdf.py --db path/to/signal.db \
 The script uses the standard `sqlite3` module and the `fpdf` package for
 PDF creation.
 
+## Interactive mode
+
+When run without command line arguments the script will prompt for the
+database path, recipient and date range. The last used database path is
+stored in `~/.signaltobook_config.json` and offered as a default on
+subsequent runs.
+


### PR DESCRIPTION
## Summary
- Allow running the Signal export script in interactive mode
- Remember the last used database path in a config file
- Document the new interactive workflow in the README

## Testing
- `python -m py_compile export_signal_pdf.py`


------
https://chatgpt.com/codex/tasks/task_b_68bae7b691e88328ba334f93cc9cc020