### PR TITLE
Add config.json support and remember date range

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ and filter the exported conversation by a date range.
 
 ```
 python export_signal_pdf.py --db path/to/signal.db \
+                            --config path/to/config.json \
                             --recipient "+4912345678" \
                             --start 2020-12-01 \
                             --end 2020-12-24 \
@@ -15,12 +16,14 @@ python export_signal_pdf.py --db path/to/signal.db \
 ```
 
 The script uses the standard `sqlite3` module and the `fpdf` package for
-PDF creation.
+PDF creation. If the database is encrypted, provide the accompanying
+`config.json` so the script can unlock it.
 
 ## Interactive mode
 
 When run without command line arguments the script will prompt for the
-database path, recipient and date range. The last used database path is
-stored in `~/.signaltobook_config.json` and offered as a default on
-subsequent runs.
+database path, the Signal `config.json` file, recipient and date range.
+These values are stored in `~/.signaltobook_config.json` and offered as
+defaults on subsequent runs. The output PDF name is derived from the
+selected date range (e.g. `chat_2020-12-01_2020-12-24.pdf`).
 

--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -21,19 +21,26 @@ query in this script targets the common tables `messages` and
 """
 
 import argparse
+import base64
 import json
 import os
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from fpdf import FPDF
 
 
-def export_chat(db_path: str, recipient: str, start_date: str,
-                end_date: str, output_pdf: str) -> None:
-    """Export messages with ``recipient`` between ``start_date`` and
-    ``end_date`` to ``output_pdf``.
+def export_chat(
+    db_path: str,
+    recipient: str,
+    start_date: str,
+    end_date: str,
+    output_pdf: str,
+    config_path: Optional[str] = None,
+) -> None:
+    """Export messages with ``recipient`` between ``start_date`` and ``end_date``.
 
     Parameters
     ----------
@@ -47,9 +54,25 @@ def export_chat(db_path: str, recipient: str, start_date: str,
         End of the period (``YYYY-MM-DD``).
     output_pdf: str
         Path to the generated PDF file.
+    config_path: Optional[str]
+        Path to the ``config.json`` containing the DB key.
     """
 
     conn = sqlite3.connect(db_path)
+
+    if config_path:
+        try:
+            with open(config_path, "r", encoding="utf-8") as fh:
+                key_b64 = json.load(fh).get("key", "")
+            if key_b64:
+                key_hex = base64.b64decode(key_b64).hex()
+                conn.execute(f"PRAGMA key = \"x'{key_hex}'\";")
+                try:
+                    conn.execute("PRAGMA cipher_migrate;")
+                except sqlite3.DatabaseError:
+                    pass
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"Warning: Could not apply key from {config_path}: {exc}")
     cur = conn.cursor()
 
     start_ts = int(datetime.strptime(start_date, "%Y-%m-%d").timestamp() * 1000)
@@ -98,6 +121,7 @@ def export_chat(db_path: str, recipient: str, start_date: str,
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Export Signal chat to PDF")
     parser.add_argument("--db", help="Path to Signal SQLite DB")
+    parser.add_argument("--config", help="Path to Signal config.json with key")
     parser.add_argument("--recipient", help="Phone number or contact identifier")
     parser.add_argument("--start", help="Start date YYYY-MM-DD")
     parser.add_argument("--end", help="End date YYYY-MM-DD")
@@ -127,13 +151,28 @@ if __name__ == "__main__":
         or cfg.get("db_path")
     )
 
+    config_path = (
+        args.config
+        or input(
+            f"Path to Signal config.json [{cfg.get('config_path', '')}]: "
+        ).strip()
+        or cfg.get("config_path")
+    )
+
     recipient = args.recipient or input("Recipient identifier: ").strip()
 
     if args.start and args.end:
         start_date, end_date = args.start, args.end
     else:
         while True:
-            date_range = input("Date range (YYYY-MM-DD YYYY-MM-DD): ").split()
+            default_range = f"{cfg.get('start_date', '')} {cfg.get('end_date', '')}".strip()
+            raw = input(
+                f"Date range (YYYY-MM-DD YYYY-MM-DD) [{default_range}]: "
+            ).strip()
+            if not raw and cfg.get("start_date") and cfg.get("end_date"):
+                start_date, end_date = cfg["start_date"], cfg["end_date"]
+                break
+            date_range = raw.split()
             if len(date_range) == 2:
                 start_date, end_date = date_range
                 try:
@@ -144,10 +183,28 @@ if __name__ == "__main__":
                     pass
             print("Please provide valid dates separated by space.")
 
+    default_output = f"chat_{start_date}_{end_date}.pdf"
     output_pdf = (
-        args.output or input("Output PDF filename [chat.pdf]: ").strip() or "chat.pdf"
+        args.output
+        or input(f"Output PDF filename [{default_output}]: ").strip()
+        or default_output
     )
 
-    save_config({**cfg, "db_path": db_path})
+    save_config(
+        {
+            **cfg,
+            "db_path": db_path,
+            "config_path": config_path,
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+    )
 
-    export_chat(db_path, recipient, start_date, end_date, output_pdf)
+    export_chat(
+        db_path,
+        recipient,
+        start_date,
+        end_date,
+        output_pdf,
+        config_path,
+    )


### PR DESCRIPTION
## Summary
- allow supplying Signal's `config.json` to unlock encrypted databases
- remember database, config path and date range between runs
- derive default PDF names from the selected date range

## Testing
- `python -m py_compile export_signal_pdf.py`
- `pip install fpdf` *(fails: Cannot connect to proxy.)*

------
https://chatgpt.com/codex/tasks/task_b_68baefb1844c83289267840d41aaf01e