### PR TITLE
Enhance database error messaging

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -58,7 +58,12 @@ def export_chat(
         Path to the ``config.json`` containing the DB key.
     """
 
-    conn = sqlite3.connect(db_path)
+    if not os.path.isfile(db_path):
+        raise SystemExit(f"Database file not found: {db_path}")
+    try:
+        conn = sqlite3.connect(db_path)
+    except sqlite3.DatabaseError as exc:
+        raise SystemExit(f"Could not open SQLite database at {db_path}: {exc}")
 
     if config_path:
         try:
@@ -90,7 +95,13 @@ def export_chat(
         """
     )
 
-    cur.execute(query, (recipient, start_ts, end_ts))
+    try:
+        cur.execute(query, (recipient, start_ts, end_ts))
+    except sqlite3.DatabaseError as exc:
+        raise SystemExit(
+            "Database query failed. Ensure the database is a valid Signal DB and "
+            f"the recipient '{recipient}' exists. Original error: {exc}"
+        )
     rows = cur.fetchall()
 
     pdf = FPDF()


### PR DESCRIPTION
## Summary
- Validate database file existence before connecting
- Add clearer error messages for database connection and query failures

## Testing
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install fpdf` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68baf13aa0508328b076194681fb850b