### PR TITLE
Handle encryptedKey in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ python export_signal_pdf.py --db path/to/signal.db \
 
 The script uses the standard `sqlite3` module and the `fpdf` package for
 PDF creation. If the database is encrypted, provide the accompanying
-`config.json` so the script can unlock it.
+`config.json` so the script can unlock it. The configuration file may
+either contain a base64 encoded `key` field or an `encryptedKey` field
+with the key already encoded as hex.
 
 ## Interactive mode
 

--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -68,9 +68,19 @@ def export_chat(
     if config_path:
         try:
             with open(config_path, "r", encoding="utf-8") as fh:
-                key_b64 = json.load(fh).get("key", "")
+                cfg = json.load(fh)
+
+            key_hex = ""
+            key_b64 = cfg.get("key", "")
+            encrypted_key = cfg.get("encryptedKey", "")
+
             if key_b64:
                 key_hex = base64.b64decode(key_b64).hex()
+            elif encrypted_key:
+                # "encryptedKey" in newer configs is already hex encoded
+                key_hex = encrypted_key
+
+            if key_hex:
                 conn.execute(f"PRAGMA key = \"x'{key_hex}'\";")
                 try:
                     conn.execute("PRAGMA cipher_migrate;")


### PR DESCRIPTION
## Summary
- support Signal configs that provide a hex encoded `encryptedKey`
- document both `key` and `encryptedKey` formats in README

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install fpdf` *(fails: Could not find a version that satisfies the requirement fpdf)*

------
https://chatgpt.com/codex/tasks/task_b_68baf62ee3a48328b4ef62c3948eee28