### PR TITLE
Add interactive recipient selection from Signal DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ with the key already encoded as hex.
 ## Interactive mode
 
 When run without command line arguments the script will prompt for the
-database path, the Signal `config.json` file, recipient and date range.
-These values are stored in `~/.signaltobook_config.json` and offered as
-defaults on subsequent runs. The output PDF name is derived from the
-selected date range (e.g. `chat_2020-12-01_2020-12-24.pdf`).
+database path and the Signal `config.json` file. It then reads all
+recipients from the database and lets you choose which conversation to
+export. After selecting the date range the values are stored in
+`~/.signaltobook_config.json` and offered as defaults on subsequent
+runs. The output PDF name is derived from the selected date range
+(e.g. `chat_2020-12-01_2020-12-24.pdf`).
 


### PR DESCRIPTION
## Summary
- Add reusable helper to open the Signal DB and list stored recipients
- Prompt user to choose a recipient by number when none is specified
- Update README to document recipient selection flow

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --db missing.db --recipient 1 --start 2020-01-01 --end 2020-01-02 --output chat.pdf` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install fpdf` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68baf866d3ec8328b9dea3ce9628826c