### PR TITLE
feat: support multiple sqlcipher bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ python export_signal_pdf.py --db path/to/signal.db \
 The script uses the standard `sqlite3` module and the `fpdf` package for
 PDF creation. Unencrypted Signal databases work out of the box. If your
 database is encrypted you must install SQLCipher-enabled Python bindings
-such as [`pysqlcipher3`](https://pypi.org/project/pysqlcipher3/) and
-provide the accompanying `config.json` so the script can unlock it. The
+such as [`pysqlcipher3`](https://pypi.org/project/pysqlcipher3/) or
+[`sqlcipher3`](https://pypi.org/project/sqlcipher3/) and provide the
+accompanying `config.json` so the script can unlock it. The
 configuration file may either contain a base64 encoded `key` field or an
 `encryptedKey` field with the key already encoded as hex.
 

--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -32,7 +32,10 @@ from typing import List, Optional
 try:
     from pysqlcipher3 import dbapi2 as sqlcipher
 except ImportError:
-    sqlcipher = None
+    try:
+        from sqlcipher3 import dbapi2 as sqlcipher
+    except ImportError:
+        sqlcipher = None
 
 from fpdf import FPDF
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fpdf
+# For encrypted databases install one of:
+# pysqlcipher3
+# sqlcipher3


### PR DESCRIPTION
## Summary
- support both pysqlcipher3 and sqlcipher3 SQLCipher bindings
- document SQLCipher binding options
- list runtime dependencies

## Testing
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install fpdf` *(fails: Could not find a version that satisfies the requirement fpdf)*

------
https://chatgpt.com/codex/tasks/task_b_68bb09be3814832897580ba39e5ffb12