### PR TITLE
Show key when database access fails

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -105,6 +105,7 @@ def open_db(db_path: str, config_path: Optional[str] = None) -> sqlite3.Connecti
             "SQLCipher support is required to open this database."
         )
 
+    key_hex = None
     if config_path:
         if not os.path.isfile(config_path):
             fail(f"Config file not found: {config_path}")
@@ -141,10 +142,10 @@ def open_db(db_path: str, config_path: Optional[str] = None) -> sqlite3.Connecti
         conn.execute("SELECT count(*) FROM sqlite_master;")
     except sqlite3.DatabaseError as exc:
         conn.close()
-        if config_path:
+        if key_hex:
             fail(
-                "Database query failed after applying key; the key might be "
-                f"wrong or the database corrupted: {exc}"
+                "Database query failed after applying key "
+                f"{key_hex}; the key might be wrong or the database corrupted: {exc}"
             )
         fail(
             "Could not read database. It may be encrypted; provide the Signal "


### PR DESCRIPTION
## Summary
- Track applied decryption key when opening the Signal DB
- Include the key in the error message if database access fails

## Testing
- `python export_signal_pdf.py --help` *(fails: No module named 'fpdf')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68bb0d935c70832882d345697ce09fcb