### PR TITLE
Add helper to decode base64 key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ python export_signal_pdf.py --db path/to/signal.db \
                             --output chat.pdf
 ```
 
+To obtain the hex-encoded key from ``config.json`` (useful for DB Browser's
+"Hex-Key" option) run:
+
+```
+python export_signal_pdf.py --config path/to/config.json --print-hex-key
+```
+
 The script relies on SQLCipher-enabled Python bindings such as
 [`pysqlcipher3`](https://pypi.org/project/pysqlcipher3/) or
 [`sqlcipher3`](https://pypi.org/project/sqlcipher3/) together with the


### PR DESCRIPTION
## Summary
- refactor key handling and add `read_key_hex` helper
- add `--print-hex-key` option to display hex key from config
- document hex key extraction usage in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf)*
- `python -m py_compile export_signal_pdf.py`


------
https://chatgpt.com/codex/tasks/task_b_68bb11178b988328b7b441d13ae8ec90