### PR TITLE
Remember last input and show conversation labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,36 +8,26 @@ and filter the exported conversation by a date range.
 
 ```
 python export_signal_pdf.py --db path/to/signal.db \
-                            --config path/to/config.json \
                             --conversation 1 \
                             --start 2020-12-01 \
                             --end 2020-12-24 \
                             --output chat.pdf
 ```
 
-To obtain the hex-encoded key from ``config.json`` (useful for DB Browser's
-"Hex-Key" option) run:
-
-```
-python export_signal_pdf.py --config path/to/config.json --print-hex-key
-```
-
 The script relies on SQLCipher-enabled Python bindings such as
 [`pysqlcipher3`](https://pypi.org/project/pysqlcipher3/) or
 [`sqlcipher3`](https://pypi.org/project/sqlcipher3/) together with the
 `fpdf` package for PDF creation. Unencrypted Signal databases can be
-opened directly, while encrypted ones require the accompanying
-`config.json` so the script can unlock them. The configuration file may
-either contain a base64 encoded `key` field or an `encryptedKey` field
-with the key already encoded as hex.
+opened directly, while encrypted ones require the associated SQLCipher
+key to access their contents.
 
 ## Interactive mode
 
 When run without command line arguments the script will prompt for the
-database path and the Signal `config.json` file. It then reads all
-conversation identifiers from the database and lets you choose which
-conversation to export. After selecting the date range the values are
-stored in `~/.signaltobook_config.json` and offered as defaults on
-subsequent runs. The output PDF name is derived from the selected date range
-(e.g. `chat_2020-12-01_2020-12-24.pdf`).
+database path. It reads all conversation identifiers from the database and
+shows available recipients with known names or phone numbers to choose from.
+After selecting the date range the values are stored in
+`~/.signaltobook_config.json` and offered as defaults on subsequent runs. The
+output PDF name is derived from the selected date range (e.g.
+`chat_2020-12-01_2020-12-24.pdf`).
 


### PR DESCRIPTION
## Summary
- persist last used database path, conversation and dates in `~/.signaltobook_config.json`
- display conversation list with known names or phone numbers
- document interactive defaults and usage

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf)*

------
https://chatgpt.com/codex/tasks/task_b_68bbfedc8ca483289120a1d397f9fb9c