### PR TITLE
Automatically download DejaVu font

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The script relies on SQLCipher-enabled Python bindings such as
 [`sqlcipher3`](https://pypi.org/project/sqlcipher3/) together with the
 `fpdf2` package for PDF creation. Unencrypted Signal databases can be
 opened directly, while encrypted ones require the associated SQLCipher
-key to access their contents. To render Unicode characters, download a
-TrueType font file such as `DejaVuSans.ttf` and place it in the project
-directory next to `export_signal_pdf.py`.
+key to access their contents. To render Unicode characters the script
+uses the `DejaVuSans` TrueType font. The file `DejaVuSans.ttf` is
+downloaded automatically if it is not present in the project directory.
 
 If the `encryptedKey` is itself encrypted, a dedicated tool may be
 required to obtain the usable key. One approach is to compile and run a

--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -23,6 +23,7 @@ query in this script targets the common tables `messages` and
 import argparse
 import json
 import os
+import urllib.request
 from datetime import datetime
 from pathlib import Path
 from typing import List, Tuple, Optional, Any
@@ -86,6 +87,28 @@ def check_readable(path: Path) -> List[Path]:
 def fail(message: str) -> None:
     """Abort execution with an error message."""
     raise SystemExit(message)
+
+
+def ensure_font(font_path: Path) -> None:
+    """Ensure that `DejaVuSans.ttf` exists at ``font_path``.
+
+    The font is downloaded automatically when missing. If the download
+    fails a :class:`FileNotFoundError` is raised to mirror the previous
+    behaviour where users had to provide the file manually.
+    """
+
+    if font_path.exists():
+        return
+
+    url = "https://github.com/dejavu-fonts/dejavu-fonts/raw/master/ttf/DejaVuSans.ttf"
+    try:
+        with urllib.request.urlopen(url) as resp:
+            font_path.write_bytes(resp.read())
+    except Exception as exc:  # pragma: no cover - network failure is rare
+        raise FileNotFoundError(
+            f"Unicode font file not found: {font_path}. Automatic download failed. "
+            "Download DejaVuSans.ttf and place it next to export_signal_pdf.py."
+        ) from exc
 
 
 class SqlCipherError(RuntimeError):
@@ -425,11 +448,7 @@ def export_chat(
 
     pdf = FPDF()
     font_path = Path(__file__).with_name("DejaVuSans.ttf")
-    if not font_path.exists():
-        raise FileNotFoundError(
-            f"Unicode font file not found: {font_path}. "
-            "Download DejaVuSans.ttf and place it next to export_signal_pdf.py."
-        )
+    ensure_font(font_path)
     pdf.add_font("DejaVu", "", str(font_path), uni=True)
     pdf.set_auto_page_break(auto=True, margin=15)
     pdf.add_page()


### PR DESCRIPTION
## Summary
- ensure DejaVuSans.ttf is downloaded automatically when missing
- update README to mention automatic font retrieval

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf2>=2.7)*
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*

------
https://chatgpt.com/codex/tasks/task_b_68bc096be4808328b4165ffdff71e645