### PR TITLE
Use bundled DejaVu Sans font

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ The script relies on SQLCipher-enabled Python bindings such as
 `fpdf2` package for PDF creation. Unencrypted Signal databases can be
 opened directly, while encrypted ones require the associated SQLCipher
 key to access their contents. To render Unicode characters the script
-uses the `DejaVuSans` TrueType font. The file `DejaVuSans.ttf` is
-downloaded automatically if it is not present in the project directory.
+uses the `DejaVuSans` TrueType font bundled in the repository under
+`dejavu-sans/DejaVuSans.ttf`.
 
 If the `encryptedKey` is itself encrypted, a dedicated tool may be
 required to obtain the usable key. One approach is to compile and run a

--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -23,7 +23,6 @@ query in this script targets the common tables `messages` and
 import argparse
 import json
 import os
-import urllib.request
 from datetime import datetime
 from pathlib import Path
 from typing import List, Tuple, Optional, Any
@@ -92,23 +91,17 @@ def fail(message: str) -> None:
 def ensure_font(font_path: Path) -> None:
     """Ensure that `DejaVuSans.ttf` exists at ``font_path``.
 
-    The font is downloaded automatically when missing. If the download
-    fails a :class:`FileNotFoundError` is raised to mirror the previous
-    behaviour where users had to provide the file manually.
+    A :class:`FileNotFoundError` is raised when the font is missing so the
+    caller can provide a helpful error message.
     """
 
     if font_path.exists():
         return
 
-    url = "https://github.com/dejavu-fonts/dejavu-fonts/raw/master/ttf/DejaVuSans.ttf"
-    try:
-        with urllib.request.urlopen(url) as resp:
-            font_path.write_bytes(resp.read())
-    except Exception as exc:  # pragma: no cover - network failure is rare
-        raise FileNotFoundError(
-            f"Unicode font file not found: {font_path}. Automatic download failed. "
-            "Download DejaVuSans.ttf and place it next to export_signal_pdf.py."
-        ) from exc
+    raise FileNotFoundError(
+        f"Unicode font file not found: {font_path}. Ensure the DejaVu Sans "
+        "font files are available."
+    )
 
 
 class SqlCipherError(RuntimeError):
@@ -447,7 +440,7 @@ def export_chat(
         return False
 
     pdf = FPDF()
-    font_path = Path(__file__).with_name("DejaVuSans.ttf")
+    font_path = Path(__file__).parent / "dejavu-sans" / "DejaVuSans.ttf"
     ensure_font(font_path)
     pdf.add_font("DejaVu", "", str(font_path), uni=True)
     pdf.set_auto_page_break(auto=True, margin=15)


### PR DESCRIPTION
## Summary
- use bundled DejaVu Sans font instead of downloading
- update README to document bundled font

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf2>=2.7; Cannot connect to proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68bc0ca0fd6483288e3e0f3ee081235d