### PR TITLE
Handle deleted messages in PDF export

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -463,6 +463,8 @@ def export_chat(
         date_str = datetime.fromtimestamp(date_ms / 1000).strftime(
             "%Y-%m-%d %H:%M"
         )
+        if not body and not attachment_path:
+            body = "Nachricht wurde gelöscht"
         text = sanitize_text(body or "", pdf)
         pdf.multi_cell(0, 10, f"{date_str}: {text}")
         if attachment_path and mime and mime.startswith("image"):


### PR DESCRIPTION
## Summary
- display placeholder text when a chat message was deleted

## Testing
- `python -m py_compile export_signal_pdf.py`


------
https://chatgpt.com/codex/tasks/task_b_68bc11fe748083289f36888ae4b05091