### PR TITLE
Add conversation name to default PDF filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ database path. It reads all conversation identifiers from the database and
 shows available recipients with known names or phone numbers to choose from.
 After selecting the date range the values are stored in
 `~/.signaltobook_config.json` and offered as defaults on subsequent runs. The
-output PDF name is derived from the selected date range (e.g.
-`chat_2020-12-01_2020-12-24.pdf`).
+output PDF name is derived from the conversation partner and date range (e.g.
+`alice_2020-12-01_2020-12-24.pdf`).  Non-alphanumeric characters are stripped
+from the conversation name.
 


### PR DESCRIPTION
## Summary
- Sanitize conversation names for use in filenames
- Include the conversation partner's name in the default PDF filename when exporting chats
- Document new filename behavior in README

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68bc113f12d88328a12aa27abfbb05d0