### PR TITLE
Handle forwarded Signal messages and improve attachment lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A simple Python utility that exports messages from a Signal SQLite
 Database to a formatted PDF document. It can include image attachments
-and filter the exported conversation by a date range.
+and filter the exported conversation by a date range. Forwarded messages
+and other text-based attachments are included, and attachment paths are
+resolved across common Signal storage locations.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- search multiple common directories for Signal attachments
- include forwarded messages by reading text-based attachments
- document and resolve attachment paths across platforms

## Testing
- `python -m py_compile export_signal_pdf.py`

------
https://chatgpt.com/codex/tasks/task_b_68bc173e39108328a0a277b0e9206b18