### PR TITLE
Fix missing HTML unescape in FPDF HTML renderer

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -38,6 +38,15 @@ except ImportError:  # pragma: no cover - fallback only used when pysqlcipher3 m
 from fpdf import FPDF, HTMLMixin
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+# Work around missing HTML2FPDF.unescape attribute in fpdf
+try:
+    from fpdf.html import HTML2FPDF  # type: ignore
+    from html import unescape as html_unescape
+    if not hasattr(HTML2FPDF, "unescape"):
+        HTML2FPDF.unescape = staticmethod(html_unescape)  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover
+    pass
+
 
 class PDF(FPDF, HTMLMixin):
     """FPDF class extended with HTML rendering support."""


### PR DESCRIPTION
## Summary
- patch export tool to add fallback `HTML2FPDF.unescape` implementation using Python's `html.unescape`

## Testing
- `python -m py_compile export_signal_pdf.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf2>=2.7)*

------
https://chatgpt.com/codex/tasks/task_b_68bc2030ecbc83289380a2744f8ecaf9