### PR TITLE
Normalize images before PDF rendering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fpdf2>=2.7
 Jinja2>=3.0
 pysqlcipher3
 # Alternatively, install `sqlcipher3` if you prefer a different binding.
+Pillow>=9.0


### PR DESCRIPTION
## Summary
- convert non-PNG/JPEG images to PNG using Pillow
- override FPDF image_map to use normalized paths and clean up temp files
- add Pillow dependency

## Testing
- `python -m py_compile export_signal_pdf.py`


------
https://chatgpt.com/codex/tasks/task_b_68bc2299d81883289a9f637cae55d9b7