### PR TITLE
Ensure UTF-8 encoded PDF output

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -628,7 +628,8 @@ def export_chat(
         )
         return False
 
-    pdf = PDF()
+    # Use UTF-8 encoding to ensure non-Latin characters are handled correctly
+    pdf = PDF(encoding="utf-8")
     font_path = Path(__file__).parent / "dejavu-sans" / "DejaVuSans.ttf"
     ensure_font(font_path)
     pdf.add_font("DejaVu", "", str(font_path), uni=True)


### PR DESCRIPTION
## Summary
- ensure `export_signal_pdf.py` creates PDFs with UTF-8 encoding to handle non-Latin text

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: No module named 'fpdf')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf2>=2.7)*

------
https://chatgpt.com/codex/tasks/task_b_68bc68dcb6048328ad6d7c72b7b12837