### PR TITLE
Remove unsupported encoding argument in PDF initialization

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -628,8 +628,8 @@ def export_chat(
         )
         return False
 
-    # Use UTF-8 encoding to ensure non-Latin characters are handled correctly
-    pdf = PDF(encoding="utf-8")
+    # Initialize PDF document with Unicode support
+    pdf = PDF()
     font_path = Path(__file__).parent / "dejavu-sans" / "DejaVuSans.ttf"
     ensure_font(font_path)
     pdf.add_font("DejaVu", "", str(font_path), uni=True)


### PR DESCRIPTION
## Summary
- Drop unsupported `encoding="utf-8"` parameter from `PDF` initialization in `export_chat`
- Ensure PDF document still initializes with Unicode support

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*


------
https://chatgpt.com/codex/tasks/task_b_68bc6c0c10a48328bf5629ca575c3d9b