### PR TITLE
Ensure Latin-1 safe text for PDF export

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -216,15 +216,9 @@ def ensure_font(font_path: Path) -> None:
     )
 
 def sanitize_text(text: str, pdf: FPDF) -> str:
-    """Return ``text`` stripped of characters unsupported by ``pdf``'s font."""
+    """Return ``text`` encoded as Latin-1, replacing unsupported chars."""
 
-    font = pdf.current_font
-    if not font:
-        return text
-    max_codepoint = font.get("maxUni", len(font.get("cw", [])) - 1)
-    return "".join(
-        ch if 0 <= ord(ch) <= max_codepoint else "?" for ch in text
-    )
+    return text.encode("latin-1", "replace").decode("latin-1")
 
 
 def resolve_attachment_path(raw_path: Optional[str]) -> Optional[str]:


### PR DESCRIPTION
## Summary
- Sanitize text by encoding to Latin-1 with replacement for unsupported characters
- Sanitize message bodies, senders, attachment names and conversation labels before writing PDF output

## Testing
- `python -m py_compile export_signal_pdf.py`


------
https://chatgpt.com/codex/tasks/task_b_68bc9729d574832893cf6ff07a9d2439