### PR TITLE
Inline styling and DejaVu font support in template

### DIFF
--- a/template.html
+++ b/template.html
@@ -2,24 +2,17 @@
 <html>
 <head>
 <meta charset="utf-8">
-<style>
-body { font-family: DejaVuSans; font-size: 12px; }
-.message { margin-bottom: 6px; }
-.meta { color: #555555; font-size: 9px; }
-.sender { font-weight: bold; }
-.text { margin-left: 5px; }
-</style>
 </head>
-<body>
+<body style="font-family:DejaVu;font-size:12px">
 <h1>{{ conversation_label }}</h1>
 {% for msg in messages %}
-<div class="message">
-  <div class="meta">{{ msg.date }} <span class="sender">{{ msg.sender }}</span></div>
-  <div class="text">{{ msg.text }}</div>
+<div style="margin-bottom:6px">
+  <div style="color:#555555;font-size:9px">{{ msg.date }} <span style="font-weight:bold">{{ msg.sender }}</span></div>
+  <div style="margin-left:5px">{{ msg.text }}</div>
   {% if msg.attachment and msg.mime and msg.mime.startswith('image') %}
     <img src="{{ msg.attachment }}" width="100">
   {% elif msg.attachment %}
-    <div class="attachment">[Attachment: {{ msg.attachment_name }}]</div>
+    <div>[Attachment: {{ msg.attachment_name }}]</div>
   {% endif %}
 </div>
 {% endfor %}


### PR DESCRIPTION
## Summary
- Replace CSS classes in `template.html` with inline `style` attributes
- Set `<body>` to use the DejaVu font at 12px to match PDF configuration

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: No module named 'fpdf')*
- `pip install fpdf2 Jinja2 Pillow` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68bc996b88b0832894717cd15f8d6d7a