### PR TITLE
Handle line breaks in message text

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -39,6 +39,7 @@ except ImportError:  # pragma: no cover - fallback only used when pysqlcipher3 m
 
 from fpdf import FPDF, HTMLMixin
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+from markupsafe import Markup
 from PIL import Image
 
 try:  # optional HEIF support
@@ -658,7 +659,7 @@ def export_chat(
         if not body and not resolved_path:
             body = "Nachricht wurde gelöscht"
 
-        text = sanitize_text(body or "", pdf)
+        text = Markup(sanitize_text(body or "", pdf).replace("\n", "<br>"))
         sender = sanitize_text(
             SELF_LABEL if is_outgoing(sender_flag) else conversation_label, pdf
         )

--- a/template.html
+++ b/template.html
@@ -8,7 +8,7 @@
 {% for msg in messages %}
 <div style="margin-bottom:6px">
   <div style="color:#555555;font-size:9px">{{ msg.date }} <span style="font-weight:bold">{{ msg.sender }}</span></div>
-  <div style="margin-left:5px">{{ msg.text }}</div>
+  <div style="margin-left:5px">{{ msg.text | replace('\n', '<br>') | safe }}</div>
   {% if msg.attachment and msg.mime and msg.mime.startswith('image') %}
     <img src="{{ msg.attachment }}" width="100">
   {% elif msg.attachment %}


### PR DESCRIPTION
## Summary
- Render message text with HTML line breaks in the template
- Preserve `<br>` tags by marking sanitized text as safe

## Testing
- ✅ `python -m py_compile export_signal_pdf.py`
- ⚠️ `pip install -r requirements.txt` *(ProxyError: Tunnel connection failed: 403 Forbidden)*
- ⚠️ `python export_signal_pdf.py --help` *(ModuleNotFoundError: No module named 'fpdf')*


------
https://chatgpt.com/codex/tasks/task_b_68bc9ad787308328a84a73aae6cd715b