### PR TITLE
Support CSS in Signal PDF templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ The PDF layout can be customized using an HTML template rendered via
 `Jinja2` and converted to PDF with `fpdf2`'s HTML capabilities. Edit the
 provided `template.html` or supply your own template file using the
 `--template` command-line option to adjust fonts, colors, or other layout
-details.
+details. Styles defined in a `<style>` block using simple selectors (e.g.
+body or `.message`) are automatically converted to inline styles so they
+render correctly in the PDF.
 
 If the `encryptedKey` is itself encrypted, a dedicated tool may be
 required to obtain the usable key. One approach is to compile and run a

--- a/template.html
+++ b/template.html
@@ -2,13 +2,21 @@
 <html>
 <head>
 <meta charset="utf-8">
+<style>
+body { font-family: DejaVuSans; font-size: 12px; }
+.message { margin-bottom: 6px; }
+.date { font-size: 6px; color: #888888; }
+.meta { color: #555555; font-size: 9px; }
+.sender { font-weight: bold; }
+.text { margin-left: 5px; }
+</style>
 </head>
-<body style="font-family:DejaVu;font-size:12px">
+<body>
 <h1>{{ conversation_label }}</h1>
 {% for msg in messages %}
-<div style="margin-bottom:6px">
-  <div style="color:#555555;font-size:9px">{{ msg.date }} <span style="font-weight:bold">{{ msg.sender }}</span></div>
-  <div style="margin-left:5px">{{ msg.text | replace('\n', '<br>') | safe }}</div>
+<div class="message">
+  <div class="meta"><span class="date">{{ msg.date }}</span> <span class="sender">{{ msg.sender }}</span></div>
+  <div class="text">{{ msg.text | replace('\n', '<br>') | safe }}</div>
   {% if msg.attachment and msg.mime and msg.mime.startswith('image') %}
     <img src="{{ msg.attachment }}" width="100">
   {% elif msg.attachment %}


### PR DESCRIPTION
## Summary
- convert `<style>` rules into inline attributes so CSS isn't printed in exported PDFs
- load the DejaVuSans font and update template to use CSS classes
- document simple stylesheet support in the README

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*


------
https://chatgpt.com/codex/tasks/task_b_68bc9c4af6e48328a90feb87aeb3f6ca