### PR TITLE
Add compatibility check for older FPDF versions

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -702,7 +702,8 @@ def export_chat(
 
     # Initialize PDF document with Unicode support
     pdf = PDF()
-    pdf.set_doc_option("core_fonts_encoding", "utf-8")
+    if hasattr(pdf, "set_doc_option"):
+        pdf.set_doc_option("core_fonts_encoding", "utf-8")
     font_path = Path(__file__).parent / "dejavu-sans" / "DejaVuSans.ttf"
     ensure_font(font_path)
     pdf.add_font("DejaVuSans", "", str(font_path), uni=True)


### PR DESCRIPTION
## Summary
- Avoid AttributeError when `set_doc_option` is missing by checking for the method before calling it

## Testing
- `python -m py_compile export_signal_pdf.py`
- `python export_signal_pdf.py --help` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install fpdf2 Jinja2 Pillow` *(fails: Could not find a version that satisfies the requirement fpdf2)*

------
https://chatgpt.com/codex/tasks/task_b_68bca496822c832888a4f4cb8291fc04