### PR TITLE
Add explicit breaks between messages in PDF

### DIFF
--- a/template.html
+++ b/template.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <style>
 body { font-family: DejaVuSans; font-size: 12px; }
-.message { margin-bottom: 6px; }
 .date { font-size: 6px; color: #888888; }
 .meta { color: #555555; font-size: 9px; }
 .sender { font-weight: bold; }
@@ -23,6 +22,7 @@ body { font-family: DejaVuSans; font-size: 12px; }
     <div>[Attachment: {{ msg.attachment_name }}]</div>
   {% endif %}
 </div>
+<br><br>
 {% endfor %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure PDF messages are separated by adding explicit `<br><br>` blocks in the HTML template, replacing unsupported CSS margins

## Testing
- `python export_signal_pdf.py --help` *(fails: No module named 'fpdf')*


------
https://chatgpt.com/codex/tasks/task_b_68bda78c3b9483289f0e6cfd66731e22