### PR TITLE
style: color headings and metadata

### DIFF
--- a/template.html
+++ b/template.html
@@ -3,10 +3,14 @@
 <head>
 <meta charset="utf-8">
 <style>
-body { 
-  font-family: DejaVuSans; 
-  font-size: 12px; 
-  line-height: 1.4; 
+body {
+  font-family: DejaVuSans;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+h1 {
+  color: #000000;       /* Überschrift schwarz */
 }
 
 .message { 
@@ -14,16 +18,17 @@ body {
   display: block;
 }
 
-.date { 
+.date {
   font-size: 8px;       /* kleiner als Haupttext */
-  color: #888888;       /* grau */
+  color: #888888;       /* Datum grau */
   display: block;
   margin-bottom: 2px;
 }
 
-.sender { 
+.sender {
   font-weight: bold;    /* fett */
   margin-left: 4px;
+  color: #0055ff;       /* Sender blau */
 }
 
 .text { 


### PR DESCRIPTION
## Summary
- Render conversation title in black to override default red heading
- Highlight sender names in blue while keeping dates gray

## Testing
- `python -m pytest -q` *(fails: No module named 'fpdf')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf2>=2.7)*

------
https://chatgpt.com/codex/tasks/task_b_68be8d3b0d048328886de0f70a27eaf5