### PR TITLE
Use font tags for date and sender colors

### DIFF
--- a/template.html
+++ b/template.html
@@ -20,7 +20,6 @@ h1 {
 
 .date {
   font-size: 8px;       /* kleiner als Haupttext */
-  color: #888888;       /* Datum grau */
   display: block;
   margin-bottom: 2px;
 }
@@ -28,7 +27,6 @@ h1 {
 .sender {
   font-weight: bold;    /* fett */
   margin-left: 4px;
-  color: #0055ff;       /* Sender blau */
 }
 
 .text { 
@@ -43,7 +41,7 @@ h1 {
 {% for msg in messages %}
 <p class="message">
   <div class="date">
-    {{ msg.date }} <span class="sender">{{ msg.sender }}</span>
+    <font color="#888888">{{ msg.date }}</font> <font color="#0055ff"><span class="sender">{{ msg.sender }}</span></font>
   </div>
   <div class="text">{{ msg.text }}</div>
   {% if msg.attachment and msg.mime and msg.mime.startswith('image') %}


### PR DESCRIPTION
## Summary
- switch chat template's date and sender display to `<font>` color tags instead of CSS classes
- remove color rules from `.date` and `.sender`

## Testing
- `python - <<'PY'
import fpdf
print(fpdf.__version__)
PY` *(fails: ModuleNotFoundError: No module named 'fpdf')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fpdf2>=2.7)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'export_signal_pdf')*


------
https://chatgpt.com/codex/tasks/task_b_68be92d64fc08328b8fcdd9110e1df87