### PR TITLE
Check macOS attachments path without space

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -189,6 +189,7 @@ ATTACHMENT_SEARCH_DIRS = [
     Path.home() / ".local/share/Signal/attachments.noindex",
     Path.home() / ".local/share/signal-desktop/attachments.noindex",
     Path.home() / "Library/Application Support/Signal/attachments.noindex",
+    Path.home() / "Library/ApplicationSupport/Signal/attachments.noindex",
     Path.home() / "AppData/Roaming/Signal/attachments.noindex",
 ]
 


### PR DESCRIPTION
## Summary
- handle macOS attachment directories both with and without a space between `Application` and `Support`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'fpdf')*


------
https://chatgpt.com/codex/tasks/task_b_68be99652570832889374bd48b597b1a