### PR TITLE
Detect mime type for attachments

### DIFF
--- a/template.html
+++ b/template.html
@@ -46,6 +46,8 @@ h1 {
   <div class="text">{{ msg.text }}</div>
   {% if msg.attachment and msg.mime and msg.mime.startswith('image') %}
     <img src="{{ msg.attachment }}" width="100">
+  {% elif msg.attachment and msg.mime and msg.mime.startswith('audio') %}
+    <div>[Voice message: {{ msg.attachment_name }}]</div>
   {% elif msg.attachment %}
     <div>[Attachment: {{ msg.attachment_name }}]</div>
   {% endif %}

--- a/tests/test_mime_detection.py
+++ b/tests/test_mime_detection.py
@@ -1,0 +1,31 @@
+import os
+import tempfile
+from pathlib import Path
+
+from PIL import Image
+import wave
+
+from export_signal_pdf import detect_mime_type
+
+
+def test_detect_mime_image():
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        Image.new('RGB', (1, 1)).save(tmp.name, format='PNG')
+        assert detect_mime_type(tmp.name) == 'image/png'
+    finally:
+        tmp.close()
+        os.unlink(tmp.name)
+
+
+def test_detect_mime_audio():
+    tmp_path = Path(tempfile.gettempdir()) / 'tmp_audio'
+    with wave.open(tmp_path, 'wb') as w:
+        w.setnchannels(1)
+        w.setsampwidth(1)
+        w.setframerate(44100)
+        w.writeframes(b'\x00' * 10)
+    try:
+        assert detect_mime_type(str(tmp_path)) == 'audio/wav'
+    finally:
+        os.unlink(tmp_path)


### PR DESCRIPTION
## Summary
- add best-effort MIME type detection for attachments without extensions
- handle audio attachments with voice message placeholders in template
- test MIME type detection helper

## Testing
- `pip install -r requirements.txt` (failed: Cannot connect to proxy: 403 Forbidden)
- `python -m pytest -q` (fails: No module named 'fpdf', 'PIL')


------
https://chatgpt.com/codex/tasks/task_b_68bea4f2c45883288516034d3fe237f0