### PR TITLE
Copy attachments to images folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ resolved across common Signal storage locations.
 Encrypted attachments are detected and transparently decrypted using the
 file keys stored in the database so that embedded images appear in the
 final PDF.
+Unencrypted attachments are copied into a temporary `images/` directory
+so that they can be referenced by the HTML template. These copies are
+removed after the PDF is generated.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- copy non-encrypted attachments to a local `images/` directory for use by the HTML template
- clean up copied attachments after PDF export
- document image copying behaviour in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'export_signal_pdf'; No module named 'PIL')*
- `pip install fpdf2 Pillow premailer` *(fails: Could not find a version that satisfies the requirement fpdf2)*
- `python -m py_compile export_signal_pdf.py`

------
https://chatgpt.com/codex/tasks/task_b_68bec649080c8328aa8f9af3d75e9f74