### PR TITLE
Log image metadata from database

### DIFF
--- a/export_signal_pdf.py
+++ b/export_signal_pdf.py
@@ -83,6 +83,16 @@ def _ensure_latin1(text: str) -> str:
 
     return text.encode("latin-1", "replace").decode("latin-1")
 
+
+def _format_enc_key(key: Any) -> str:
+    """Return a hex representation of an attachment encryption key."""
+
+    if key is None:
+        return "None"
+    if isinstance(key, (bytes, bytearray, memoryview)):
+        return bytes(key).hex()
+    return str(key)
+
 # Work around missing HTML2FPDF.unescape attribute in fpdf
 try:
     from fpdf.html import HTML2FPDF  # type: ignore
@@ -835,6 +845,13 @@ def export_chat(
     messages: List[dict] = []
 
     for date_ms, body, attachment_path, mime, enc_key, sender_flag in rows:
+        if attachment_path and mime and mime.startswith("image"):
+            logger.info(
+                "DB image metadata: path=%s mime=%s key=%s",
+                attachment_path,
+                mime,
+                _format_enc_key(enc_key),
+            )
         date_str = datetime.fromtimestamp(date_ms / 1000).strftime(
             "%Y-%m-%d %H:%M"
         )


### PR DESCRIPTION
## Summary
- add `_format_enc_key` helper to render attachment encryption keys
- log image attachment mime type and database key for debugging

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'fpdf')*

------
https://chatgpt.com/codex/tasks/task_b_68becface0f4832883c5e571e6ae1107